### PR TITLE
Auto-Commit PR at 20250327_080930

### DIFF
--- a/logs/log.txt
+++ b/logs/log.txt
@@ -1,0 +1,1 @@
+20250327_080930: Failed to fetch quote: HTTPSConnectionPool(host='api.quotable.io', port=443): Max retries exceeded with url: /random (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1000)'))) - Unknown Author


### PR DESCRIPTION
Automated commit from fork:

20250327_080930: Failed to fetch quote: HTTPSConnectionPool(host='api.quotable.io', port=443): Max retries exceeded with url: /random (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1000)'))) - Unknown Author
